### PR TITLE
support Google SMTP server

### DIFF
--- a/email.go
+++ b/email.go
@@ -181,7 +181,12 @@ func NewSMTP(rawURL string) (*SMTP, error) {
 
 	if url.User != nil {
 		p, _ := url.User.Password()
-		a := smtp.CRAMMD5Auth(url.User.Username(), p)
+
+		// - put host:port in the fourth argument here as there is a "wrong host name"
+		//   check in go SMTP library auth.go, May have better solution but need
+		//   to understand the purpose of the check
+		a := smtp.PlainAuth("", url.User.Username(), p, mysmtp.server)
+
 		mysmtp.auth = &a
 	}
 	return mysmtp, nil


### PR DESCRIPTION
Changing to PlainAuth should improve comparability. Apart Google SMTP, I also tested one other SMTP server from my hosting service and it works well (it is also SSL-based).

Also, it is important to test this change against https://test-proposals.decred.org/ for whatever SMTP server that it is currently using. I don't have access to the site so that owner needs to confirm that it is working for the original SMTP server.