### PR TITLE
tls: Accept tls pointer to avoid lock copy

### DIFF
--- a/email.go
+++ b/email.go
@@ -169,7 +169,7 @@ func (m *Message) Recipients() []string {
 }
 
 // NewSMTP is called with smtp[s]://[username:[password]]@server:[port]
-func NewSMTP(rawURL string, tlsConfig tls.Config) (*SMTP, error) {
+func NewSMTP(rawURL string, tlsConfig *tls.Config) (*SMTP, error) {
 	url, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, err
@@ -187,7 +187,7 @@ func NewSMTP(rawURL string, tlsConfig tls.Config) (*SMTP, error) {
 	mysmtp := &SMTP{
 		scheme:    url.Scheme,
 		hostname:  hostname,
-		tlsConfig: &tlsConfig,
+		tlsConfig: tlsConfig,
 	}
 
 	_, _, err = net.SplitHostPort(url.Host)


### PR DESCRIPTION
Passing tls.Config directly results in a copy of the mutex.  Passing via
pointer instead helps ensure that there is no accidental use of a
lock/unlock on a copy of the mutex rather than the same.

This is throwing warnings for me in my editor.  An explanation of the reason for the warning can be found here:

https://medium.com/golangspec/detect-locks-passed-by-value-in-go-efb4ac9a3f2b

It's not going to cause a problem the way it's implemented at the moment in goemail, but at least if it's passed via pointer it reduces the chance that future changes to the code will get into trouble.