### PR TITLE
add NewMessageType that checks if address has name already

### DIFF
--- a/email_test.go
+++ b/email_test.go
@@ -10,6 +10,101 @@ import (
 	"testing"
 )
 
+func TestNewMessageType(t *testing.T) {
+	type args struct {
+		from        string
+		subject     string
+		body        string
+		contentType string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantName   string
+		wantFrom   string
+		wantNilMsg bool
+	}{
+		{
+			name: "plain",
+			args: args{
+				from:        "boring@email.com",
+				subject:     "boring plain email",
+				body:        "nothing to see here",
+				contentType: "text/plain",
+			},
+			wantName:   "",
+			wantFrom:   "boring@email.com",
+			wantNilMsg: false,
+		},
+		{
+			name: "both",
+			args: args{
+				from:        "Boring Guy <boring@email.com>",
+				subject:     "boring plain email",
+				body:        "nothing to see here",
+				contentType: "text/plain",
+			},
+			wantName:   "Boring Guy",
+			wantFrom:   "boring@email.com",
+			wantNilMsg: false,
+		},
+		{
+			name: "invalid",
+			args: args{
+				from:        "boring-email.com",
+				subject:     "boring plain email",
+				body:        "nothing to see here",
+				contentType: "text/plain",
+			},
+			wantName:   "",
+			wantFrom:   "",
+			wantNilMsg: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := NewMessageType(tt.args.from, tt.args.subject, tt.args.body, tt.args.contentType)
+			if (msg == nil) != tt.wantNilMsg {
+				t.Errorf("Message was not nil. Should have been invalid.")
+			}
+			if msg == nil {
+				return
+			}
+			gotFrom := msg.From()
+			if gotFrom != tt.wantFrom {
+				t.Errorf("Incorrect From. Got %s, expected %s",
+					gotFrom, tt.wantFrom)
+			}
+			gotName := msg.Name()
+			if gotName != tt.wantName {
+				t.Errorf("Incorrect Name. Got %s, expected %s",
+					gotName, tt.wantName)
+			}
+			t.Logf(`Input: "%s". Name: "%s". From: "%s".`, tt.args.from,
+				gotName, gotFrom)
+		})
+	}
+}
+
+func TestIsValidAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		isOk bool
+	}{
+		{"ok plain", "boring@email.com", true},
+		{"ok named", "Boring Guy <boring@email.com>", true},
+		{"bad", "boring-email.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidAddress(tt.addr); got != tt.isOk {
+				t.Errorf("IsValidAddress() = %v, want %v", got, tt.isOk)
+			}
+		})
+	}
+}
+
 func TestMessage_Body(t *testing.T) {
 	body := `This is the body of the email.
 	


### PR DESCRIPTION
This adds `NewMessageType`, which checks if the supplied address already has a name portion.

e.g. `"John Doe <jdoe@asdf.com>"`

`NewMessage` and `NewHTMLMessage` wrap `NewMessageType`.
Also add `IsValidAddress`, presently for external use.
Add tests.